### PR TITLE
JwtProvider가 없어 테스트 실패하는 버그 해결

### DIFF
--- a/src/main/resources/docs/index.html
+++ b/src/main/resources/docs/index.html
@@ -681,7 +681,7 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2025-01-27 19:53:09 +0900
+Last updated 2025-02-03 14:54:42 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/org/bee/metro/context/DocumentTest.java
+++ b/src/test/java/org/bee/metro/context/DocumentTest.java
@@ -3,7 +3,7 @@ package org.bee.metro.context;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.bee.metro.core.auth.api.AuthApi;
 import org.bee.metro.core.auth.application.AuthService;
-import org.bee.metro.global.auth.jwt.RefreshTokenProvider;
+import org.bee.metro.document.config.DocumentConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -13,7 +13,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(value = {AuthApi.class})
-@Import(RefreshTokenProvider.class)
+@Import({DocumentConfig.class})
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
 public abstract class DocumentTest {

--- a/src/test/java/org/bee/metro/document/config/DocumentConfig.java
+++ b/src/test/java/org/bee/metro/document/config/DocumentConfig.java
@@ -1,0 +1,17 @@
+package org.bee.metro.document.config;
+
+import org.bee.metro.global.auth.jwt.RefreshTokenProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class DocumentConfig {
+
+    @Bean
+    public RefreshTokenProvider refreshTokenProvider(
+            @Value("${jwt.refresh.issuer}") String issuer,
+            @Value("${jwt.refresh.secret}") String secret) {
+        return new RefreshTokenProvider(issuer, secret);
+    }
+}


### PR DESCRIPTION
## 📄 Summary

> 테스트 성공을 위해 RefreshTokenProvider를 빈으로 만들어 줬습니다!

## 🙋🏻 More

> 갑작스러운 테스트 실패...