### PR TITLE
Feat: 문서 도메인을 구현합니다

### DIFF
--- a/src/main/java/org/bee/metro/core/document/domain/Document.java
+++ b/src/main/java/org/bee/metro/core/document/domain/Document.java
@@ -1,0 +1,48 @@
+package org.bee.metro.core.document.domain;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.bee.metro.core.document.exception.DocumentErrorCode;
+import org.bee.metro.global.exception.type.BadRequestException;
+
+public class Document {
+
+    private final UUID id;
+    private final String title;
+    private final String tag;
+    private final String cover;
+    private final UUID parentId;
+    private final UUID ownerId;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public static final String ERROR_PARENT_ID_IS_NULL = "부모 아이디는 null일 수 없습니다.";
+    public static final String ERROR_OWNER_ID_IS_NULL = "소유자 아이디는 null일 수 없습니다.";
+
+    public Document(UUID id, String title, String tag, String cover, UUID parentId, UUID ownerId,
+                    LocalDateTime createdAt, LocalDateTime updatedAt) {
+        validateParentId(parentId);
+        validateOwnerId(ownerId);
+
+        this.id = id;
+        this.title = title;
+        this.tag = tag;
+        this.cover = cover;
+        this.parentId = parentId;
+        this.ownerId = ownerId;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    private void validateParentId(UUID parentId) {
+        if (parentId == null) {
+            throw new BadRequestException(ERROR_PARENT_ID_IS_NULL, DocumentErrorCode.ARGUMENT_IS_NULL);
+        }
+    }
+
+    private void validateOwnerId(UUID ownerId) {
+        if (ownerId == null) {
+            throw new BadRequestException(ERROR_OWNER_ID_IS_NULL, DocumentErrorCode.ARGUMENT_IS_NULL);
+        }
+    }
+}

--- a/src/main/java/org/bee/metro/core/document/domain/DocumentRepository.java
+++ b/src/main/java/org/bee/metro/core/document/domain/DocumentRepository.java
@@ -1,0 +1,4 @@
+package org.bee.metro.core.document.domain;
+
+public interface DocumentRepository {
+}

--- a/src/main/java/org/bee/metro/core/document/entity/DocumentEntity.java
+++ b/src/main/java/org/bee/metro/core/document/entity/DocumentEntity.java
@@ -11,12 +11,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.bee.metro.global.entity.BaseEntity;
 
 @Entity
 @Getter
 @Table(name = "DOCUMENT")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class DocumentEntity {
+public class DocumentEntity extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/src/main/java/org/bee/metro/core/document/entity/DocumentEntity.java
+++ b/src/main/java/org/bee/metro/core/document/entity/DocumentEntity.java
@@ -1,0 +1,47 @@
+package org.bee.metro.core.document.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "DOCUMENT")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DocumentEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    @Column(nullable = true)
+    private String title;
+
+    @Column(nullable = true)
+    private String tag;
+
+    @Column(nullable = true)
+    private String cover;
+
+    private UUID parentId;
+
+    private UUID ownerId;
+
+    @Builder
+    public DocumentEntity(UUID id, String title, String tag, String cover, UUID parentId, UUID ownerId) {
+        this.id = id;
+        this.title = title;
+        this.tag = tag;
+        this.cover = cover;
+        this.parentId = parentId;
+        this.ownerId = ownerId;
+    }
+}

--- a/src/main/java/org/bee/metro/core/document/exception/DocumentErrorCode.java
+++ b/src/main/java/org/bee/metro/core/document/exception/DocumentErrorCode.java
@@ -1,0 +1,25 @@
+package org.bee.metro.core.document.exception;
+
+import org.bee.metro.global.exception.ErrorCode;
+
+public enum DocumentErrorCode implements ErrorCode {
+    ;
+
+    private final String code;
+    private final String message;
+
+    DocumentErrorCode(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/org/bee/metro/core/document/exception/DocumentErrorCode.java
+++ b/src/main/java/org/bee/metro/core/document/exception/DocumentErrorCode.java
@@ -3,6 +3,7 @@ package org.bee.metro.core.document.exception;
 import org.bee.metro.global.exception.ErrorCode;
 
 public enum DocumentErrorCode implements ErrorCode {
+    ARGUMENT_IS_NULL("D001", "해당 인자는 null일 수 없습니다")
     ;
 
     private final String code;


### PR DESCRIPTION
## 📄 Summary

> 문서 도메인을 구현했습니다!

- `Document`, `DocumentEntity`, `DocumentRepsitory` 생성 및 구현했습니다
- 현재는 parentId, ownerId에 대한 NULL 체크(외래키 X)만 진행하고 있습니다

## 🙋🏻 More

> 오늘 하루 화이팅!